### PR TITLE
Update pipeline to notify both build and pack.

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,6 +1,4 @@
 branch: master
-dryRun: false
-ci: true
 plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,36 @@ jobs:
       arguments: '--configuration $(buildConfiguration)'
       publishTestResults: true 
 
+  - powershell: |
+      echo "##vso[task.setvariable variable=teamProject;isOutput=true]$env:SYSTEM_TEAMPROJECT"
+      echo "##vso[task.setvariable variable=jobStatus;isOutput=true]$env:AGENT_JOBSTATUS"
+      echo "##vso[task.setvariable variable=collectionUri;isOutput=true]$env:SYSTEM_COLLECTIONURI"
+      echo "##vso[task.setvariable variable=buildId;isOutput=true]$env:BUILD_BUILDID"
+    name: setOutputVars
+
+- job: NotifyBuild
+  dependsOn: Build
+  pool: server
+  variables:
+    teamProject: $[ dependencies.Build.outputs['setOutputVars.teamProject'] ]
+    jobStatus: $[ dependencies.Build.outputs['setOutputVars.jobStatus'] ]
+    collectionUri: $[ dependencies.Build.outputs['setOutputVars.collectionUri'] ]
+    buildId: $[ dependencies.Build.outputs['setOutputVars.buildId'] ]
+    message: |
+      "New CI build on $(teamProject).
+      Status: $(jobStatus)
+      <$(collectionUri)/$(teamProject)/_build/results?buildId=$(buildId)&view=logs|Details>"
+  steps:
+  - task: InvokeRESTAPI@1
+    inputs:
+      connectionType: connectedServiceName
+      serviceConnection: SlackWebHook
+      method: POST
+      body: |
+        {
+          "text": $(message)
+        }
+
 - job: Pack
   dependsOn: Build
   condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'master'))
@@ -52,6 +82,7 @@ jobs:
 
   - task: DotNetCoreCLI@2
     displayName: 'Pack'
+    condition: succeeded()
     inputs:
       command: pack
       packagesToPack: 'Cache.Core/Cache.Core.csproj'
@@ -66,25 +97,21 @@ jobs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)' 
 
   - powershell: |
-      echo "##vso[task.setvariable variable=teamProject;isOutput=true]$env:SYSTEM_TEAMPROJECT"
       echo "##vso[task.setvariable variable=jobStatus;isOutput=true]$env:AGENT_JOBSTATUS"
-      echo "##vso[task.setvariable variable=collectionUri;isOutput=true]$env:SYSTEM_COLLECTIONURI"
-      echo "##vso[task.setvariable variable=buildId;isOutput=true]$env:BUILD_BUILDID"
       echo "##vso[task.setvariable variable=versionNumber;isOutput=true]$(nextRelease)"
     name: setOutputVars
-    condition: succeeded()
     
 - job: Notify
   dependsOn: Pack
   pool: server
   variables:
-    teamProject: $[ dependencies.Pack.outputs['setOutputVars.teamProject'] ]
-    versionNumber: $[ dependencies.Pack.outputs['setOutputVars.versionNumber'] ]
+    teamProject: $[ dependencies.Build.outputs['setOutputVars.teamProject'] ]
+    collectionUri: $[ dependencies.Build.outputs['setOutputVars.collectionUri'] ]
+    buildId: $[ dependencies.Build.outputs['setOutputVars.buildId'] ]
     jobStatus: $[ dependencies.Pack.outputs['setOutputVars.jobStatus'] ]
-    collectionUri: $[ dependencies.Pack.outputs['setOutputVars.collectionUri'] ]
-    buildId: $[ dependencies.Pack.outputs['setOutputVars.buildId'] ]
+    versionNumber: $[ dependencies.Pack.outputs['setOutputVars.versionNumber'] ]
     message: |
-      "New version on $(teamProject): $(versionNumber).
+      "New version on $(teamProject): $(versionNumber)
       Status: $(jobStatus)
       <$(collectionUri)/$(teamProject)/_build/results?buildId=$(buildId)&view=logs|Details>"
   steps:


### PR DESCRIPTION
Update pipeline to notify both build and pack.
Only run pack when semantic-release succeeded.